### PR TITLE
feat: render posts and navigation from json

### DIFF
--- a/src/app/[slug]/page.tsx
+++ b/src/app/[slug]/page.tsx
@@ -1,0 +1,22 @@
+import { getPostBySlug } from "@/lib/posts";
+import { notFound } from "next/navigation";
+
+export default async function PostPage({
+  params,
+}: {
+  params: { slug: string };
+}) {
+  const post = await getPostBySlug(params.slug);
+  if (!post || post.post_status !== "publish") {
+    notFound();
+  }
+  return (
+    <article className="max-w-3xl mx-auto p-6 prose">
+      <h1 className="mb-2">{post.post_title}</h1>
+      <p className="text-sm text-gray-500 mb-6">
+        {new Date(post.post_date).toLocaleDateString("vi-VN")}
+      </p>
+      <div dangerouslySetInnerHTML={{ __html: post.post_content }} />
+    </article>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -11,6 +11,7 @@ import Providers from "./providers";
 import customFetch from "@/lib/axios/custom";
 import { Company } from "@/types/company.types";
 import { headers } from "next/headers";
+import { getNavItems } from "@/lib/posts";
 
 // Hàm fetch thông tin công ty (dùng lại)
 async function getCompanyInfo() {
@@ -54,6 +55,7 @@ export default async function RootLayout({
   children: React.ReactNode;
 }>) {
   const company = await getCompanyInfo();
+  const navItems = await getNavItems();
 
   return (
     <html lang="en">
@@ -61,7 +63,7 @@ export default async function RootLayout({
         <HolyLoader color="#868686" />
         <TopBanner company={company} />
         <Providers>
-          <TopNavbar company={company} />
+          <TopNavbar company={company} items={navItems} />
           {children}
         </Providers>
         <Footer company={company} />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,27 +1,7 @@
 import Image from "next/image";
-import fs from "fs/promises";
-import path from "path";
-
-interface Post {
-  ID: number;
-  post_title: string;
-  post_date: string;
-  post_content: string;
-  post_status: string;
-  post_type: string;
-}
-
-async function getPosts(): Promise<Post[]> {
-  const filePath = path.join(process.cwd(), "public", "json", "bz_posts.json");
-  const data = await fs.readFile(filePath, "utf8");
-  return JSON.parse(data) as Post[];
-}
+import PostList from "@/components/posts/PostList";
 
 export default async function Home() {
-  const posts = (await getPosts()).filter(
-    (p) => p.post_status === "publish" && p.post_type === "post"
-  );
-
   return (
     <main>
       <section className="relative h-[400px] w-full">
@@ -38,19 +18,7 @@ export default async function Home() {
       </section>
       <section className="max-w-5xl mx-auto p-6">
         <h2 className="text-2xl font-semibold mb-4">Bài viết mới nhất</h2>
-        <ul className="grid gap-6 md:grid-cols-2">
-          {posts.map((post) => (
-            <li key={post.ID} className="border rounded-lg p-4 shadow-sm">
-              <h3 className="text-lg font-medium mb-2">{post.post_title}</h3>
-              <p className="text-sm text-gray-500 mb-2">
-                {new Date(post.post_date).toLocaleDateString("vi-VN")}
-              </p>
-              <p className="text-sm text-gray-700">
-                {post.post_content.replace(/<[^>]+>/g, "").slice(0, 120)}...
-              </p>
-            </li>
-          ))}
-        </ul>
+        <PostList />
       </section>
     </main>
   );

--- a/src/components/layout/Navbar/TopNavbar/index.tsx
+++ b/src/components/layout/Navbar/TopNavbar/index.tsx
@@ -4,25 +4,22 @@ import { integralCF } from "@/styles/fonts";
 import Link from "next/link";
 import ResTopNavbar from "./ResTopNavbar";
 import { Button } from "@/components/ui/button";
-import { NavItem } from "../navbar.types";
 import { Company } from "@/types/company.types";
+import { NavMenu } from "../navbar.types";
 
-const NAV_ITEMS: NavItem[] = [
-  { id: 1, label: "Trang chủ", url: "/" },
-  { id: 2, label: "Giới thiệu", url: "/gioi-thieu" },
-  { id: 3, label: "Dịch vụ", url: "/dich-vu" },
-  { id: 4, label: "Dự án", url: "/du-an" },
-  { id: 5, label: "Tin tức", url: "/tin-tuc" },
-  { id: 6, label: "Liên hệ", url: "/lien-he" },
-];
-
-const TopNavbar = ({ company }: { company: Company | null }) => {
+const TopNavbar = ({
+  company,
+  items,
+}: {
+  company: Company | null;
+  items: NavMenu;
+}) => {
   return (
     <nav className="sticky top-0 bg-white z-20">
       <div className="flex relative max-w-frame mx-auto items-center justify-between py-5 md:py-6 px-4 xl:px-0">
         <div className="flex items-center">
           <div className="block md:hidden mr-4">
-            <ResTopNavbar items={NAV_ITEMS} companyName={company?.name} />
+            <ResTopNavbar items={items} companyName={company?.name} />
           </div>
           <Link
             href="/"
@@ -36,7 +33,7 @@ const TopNavbar = ({ company }: { company: Company | null }) => {
           </Link>
         </div>
         <div className="hidden md:flex items-center space-x-6">
-          {NAV_ITEMS.map((item) => (
+          {items.map((item) => (
             <Link key={item.id} href={item.url} className="text-sm font-medium">
               {item.label}
             </Link>

--- a/src/components/posts/PostCard.tsx
+++ b/src/components/posts/PostCard.tsx
@@ -1,0 +1,18 @@
+import Link from "next/link";
+import { BzPost } from "@/lib/posts";
+
+export default function PostCard({ post }: { post: BzPost }) {
+  return (
+    <li className="border rounded-lg p-4 shadow-sm">
+      <h3 className="text-lg font-medium mb-2">
+        <Link href={`/${post.post_name}`}>{post.post_title}</Link>
+      </h3>
+      <p className="text-sm text-gray-500 mb-2">
+        {new Date(post.post_date).toLocaleDateString("vi-VN")}
+      </p>
+      <p className="text-sm text-gray-700">
+        {post.post_content.replace(/<[^>]+>/g, "").slice(0, 120)}...
+      </p>
+    </li>
+  );
+}

--- a/src/components/posts/PostList.tsx
+++ b/src/components/posts/PostList.tsx
@@ -1,0 +1,13 @@
+import { getPublishedPosts } from "@/lib/posts";
+import PostCard from "./PostCard";
+
+export default async function PostList() {
+  const posts = await getPublishedPosts();
+  return (
+    <ul className="grid gap-6 md:grid-cols-2">
+      {posts.map((post) => (
+        <PostCard key={post.ID} post={post} />
+      ))}
+    </ul>
+  );
+}

--- a/src/lib/posts.ts
+++ b/src/lib/posts.ts
@@ -1,0 +1,45 @@
+import fs from "fs/promises";
+import path from "path";
+import { NavItem } from "@/components/layout/Navbar/navbar.types";
+
+export interface BzPost {
+  ID: number;
+  post_title: string;
+  post_date: string;
+  post_content: string;
+  post_status: string;
+  post_type: string;
+  post_name: string;
+  menu_order?: number;
+}
+
+const dataPath = path.join(process.cwd(), "public", "json", "bz_posts.json");
+
+async function readAll(): Promise<BzPost[]> {
+  const data = await fs.readFile(dataPath, "utf8");
+  return JSON.parse(data) as BzPost[];
+}
+
+export async function getPublishedPosts(): Promise<BzPost[]> {
+  const posts = await readAll();
+  return posts.filter(
+    (p) => p.post_status === "publish" && p.post_type === "post"
+  );
+}
+
+export async function getNavItems(): Promise<NavItem[]> {
+  const posts = await readAll();
+  return posts
+    .filter((p) => p.post_type === "nav_menu_item")
+    .sort((a, b) => (a.menu_order ?? 0) - (b.menu_order ?? 0))
+    .map((p) => ({
+      id: p.ID,
+      label: p.post_title,
+      url: p.post_name === "trang-chu" ? "/" : `/${p.post_name}`,
+    }));
+}
+
+export async function getPostBySlug(slug: string): Promise<BzPost | undefined> {
+  const posts = await readAll();
+  return posts.find((p) => p.post_name === slug);
+}


### PR DESCRIPTION
## Summary
- read WordPress-style JSON posts and nav items
- build PostCard and PostList components for rendering posts
- load navigation from JSON in layout and show post pages by slug

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(incomplete: How would you like to configure ESLint?)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689b7376bf648325822c89fc4a14c4d5